### PR TITLE
Fix commerce-mock-lite documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./${{ matrix.app }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/commerce-mock-lite/README.md
+++ b/commerce-mock-lite/README.md
@@ -42,7 +42,7 @@ kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/mast
 kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/commerce-mock-lite/deployment/kyma.yaml -n mocks
 ```
 
-These commands expose the UI and API of the mock via an `APIRule` resource and makes the UI accessible at `https://commerce.{yourDomain}`.
+These commands expose the UI and API of the mock via an `APIRule` resource and makes the UI accessible at `https://commerce-lite.{yourDomain}`.
 
 ## Run mock on Kubernetes
 

--- a/commerce-mock-lite/README.md
+++ b/commerce-mock-lite/README.md
@@ -16,7 +16,6 @@ docker run -d \
 
 ### Access the mock locally
 
-* For mock UI, see `http://localhost:10000`
 * For the API to pair the mock, see `http://localhost:10000/console`
 * For mocked APIs, see:
   * `http://localhost:10000/rest/v2/console`
@@ -42,7 +41,7 @@ kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/mast
 kubectl apply -f https://raw.githubusercontent.com/SAP/xf-application-mocks/master/commerce-mock-lite/deployment/kyma.yaml -n mocks
 ```
 
-These commands expose the UI and API of the mock via an `APIRule` resource and makes the UI accessible at `https://commerce-lite.{yourDomain}`.
+These commands expose the API of the mock via an `APIRule` resource and makes it accessible at `https://commerce-lite.{yourDomain}`.
 
 ## Run mock on Kubernetes
 


### PR DESCRIPTION
There are 2 problems with the current README:
1. Hostname does not match the one from the APIRule: should be `commerce-lite` instead of `commerce`
2. Commerce-mock-lite does not expose a UI, but the README mentions it