### PR TITLE
disable image publishing for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./${{ matrix.app }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The github actions for PRs are failing at the docker push phase with error `error: denied: installation not allowed to Write organization package `
According to [this discussion](https://github.community/t/cant-authenticate-with-actions-token-for-pr-event/170752/16) there is no trivial solution for now. As anyway we should not pollute the registry with PR images, I disabled the publishing for PRs.
